### PR TITLE
Updates jsonapi-resources to 0.8.0; Removes piped_ruby

### DIFF
--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_runtime_dependency 'jsonapi-resources', '0.8.0.beta2'
+  spec.add_runtime_dependency 'jsonapi-resources', '~> 0.8.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/jsonapi-utils.gemspec
+++ b/jsonapi-utils.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'jsonapi-resources', '0.8.0.beta2'
-  spec.add_runtime_dependency 'piped_ruby', '0.2.1'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/jsonapi/utils.rb
+++ b/lib/jsonapi/utils.rb
@@ -4,7 +4,6 @@ require 'jsonapi/utils/exceptions'
 require 'jsonapi/utils/request'
 require 'jsonapi/utils/response'
 require 'jsonapi/utils/support/filter/custom'
-require 'piped_ruby'
 
 JSONAPI::Resource.extend JSONAPI::Utils::Support::Filter::Custom
 

--- a/lib/jsonapi/utils/response/formatters.rb
+++ b/lib/jsonapi/utils/response/formatters.rb
@@ -57,11 +57,10 @@ module JSONAPI
         end
 
         def build_collection(records, options = {})
-          -> { apply_filter(records, options) }
-            .>> { |filtered| apply_pagination(filtered, options) }
-            .>> { |paginated| apply_sort(paginated) }
-            .>> { |result| result.map { |record| turn_into_resource(record, options) } }
-            .unwrap
+          records = apply_filter(records, options)
+          records = apply_pagination(records, options)
+          records = apply_sort(records)
+          records.respond_to?(:to_ary) ? records.map { |record| turn_into_resource(record, options) } : []
         end
 
         def turn_into_resource(record, options = {})


### PR DESCRIPTION
Updates gemspec to reflect the new non-beta version;

Removes dependency for a gem that isn't necessary -- piped_ruby is a convenience gem that  should be added to an entire project only by the end user.  It's not needed for this gem to work properly, and its inclusion modifies entire projects that may not want it.
